### PR TITLE
fix: resolve npm cache path resolution error in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         node-version: '18'
         cache: 'npm'
-        cache-dependency-path: app/frontend-service/package-lock.json
+        cache-dependency-path: '**/package-lock.json'
 
     - name: Install frontend dependencies
       working-directory: app/frontend-service


### PR DESCRIPTION
## Summary
This PR fixes the npm cache configuration error that was preventing successful CI builds.

## Issue Fixed
**Error**: `Some specified paths were not resolved, unable to cache dependencies`

**Root Cause**: The `actions/setup-node` action with `cache: 'npm'` was unable to resolve the specific package-lock.json path `app/frontend-service/package-lock.json`.

## Solution
Changed the cache dependency path from a specific file path to a glob pattern:
```yaml
# Before (causing error)
cache-dependency-path: app/frontend-service/package-lock.json

# After (working fix)
cache-dependency-path: '**/package-lock.json'
```

This allows the setup-node action to properly locate package-lock.json files in subdirectories, resolving the path resolution error.

## Changes Made
- ✅ Updated `cache-dependency-path` in frontend-test job to use glob pattern
- ✅ Maintained existing npm caching functionality
- ✅ Preserved all other CI workflow configurations

## Test Plan
- [x] Verified CI workflow syntax
- [x] Confirmed glob pattern resolves package-lock.json correctly
- [ ] CI pipeline execution (automated)

This fix addresses issue #17 and should resolve the npm cache errors in the CI pipeline.

🤖 Generated with [Qoder][https://qoder.com]