### PR TITLE
debug: add file structure debugging for frontend tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,17 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: Debug file structure
+      working-directory: app/frontend-service
+      run: |
+        echo "Current directory: $(pwd)"
+        echo "Listing src directory:"
+        ls -la src/
+        echo "Listing test files:"
+        find src/ -name "*.test.js" -o -name "*.spec.js"
+        echo "Vitest config:"
+        cat vitest.config.js
+
     - name: Set up Node.js
       uses: actions/setup-node@v3
       with:


### PR DESCRIPTION
## Summary
This PR adds debugging steps to investigate why frontend unit tests are not being found in the CI environment, despite working locally.

## Issue
Frontend unit tests run successfully locally but fail in CI with:
```
No test files found, exiting with code 1
```

## Debugging Approach
Added a debug step in the CI workflow that will:
- Show current working directory
- List contents of the src directory
- Find all test files (.test.js and .spec.js)
- Display the vitest configuration

This will help identify if:
1. Files are not being checked out properly in CI
2. Working directory issues
3. File permission problems
4. Path resolution differences between local and CI environments

## Next Steps
After merging this PR, we'll be able to see the CI logs to understand why the test files aren't being discovered, then apply the appropriate fix.

Related to issue #19

🤖 Generated with [Qoder][https://qoder.com]