### PR TITLE
feat: enable frontend integration tests in CI with service dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,28 @@ jobs:
       run: |
         npm run test:unit
 
+    - name: Set up Docker Compose
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y docker-compose
+
+    - name: Start required services for integration tests
+      working-directory: app
+      run: |
+        # Start databases and backend services
+        docker-compose up -d mongo postgres user-service chat-service message-service gateway-service
+        # Wait for services to be ready
+        sleep 30
+        # Verify services are running
+        docker-compose ps
+
     - name: Run frontend integration tests
       working-directory: app/frontend-service
       run: |
-        npm run test:integration || echo "Integration tests skipped in CI environment"
+        npm run test:integration
       env:
         TEST_API_BASE_URL: http://localhost:8000
-        TEST_TIMEOUT: 15000
+        TEST_TIMEOUT: 30000
 
     - name: Run frontend linting
       working-directory: app/frontend-service

--- a/app/frontend-service/vitest.integration.config.js
+++ b/app/frontend-service/vitest.integration.config.js
@@ -1,19 +1,15 @@
 import { defineConfig } from 'vite';
 
-// Skip integration tests in CI environment since they require running services
-// eslint-disable-next-line no-undef
-const isInCI = process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true';
-
 export default defineConfig({
   test: {
     environment: 'node',
     setupFiles: ['./src/__integration-tests__/setup.integration.js'],
     globals: true,
-    include: isInCI ? [] : ['src/__integration-tests__/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    include: ['src/__integration-tests__/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     exclude: ['node_modules/**', 'dist/**'],
-    testTimeout: 15000,
-    hookTimeout: 15000,
-    teardownTimeout: 5000,
+    testTimeout: 30000,
+    hookTimeout: 30000,
+    teardownTimeout: 10000,
     reporters: ['verbose'],
     coverage: {
       enabled: true,


### PR DESCRIPTION
## Summary
- Enable frontend integration tests to run in CI environment
- Start required backend services (mongo, postgres, user-service, chat-service, message-service, gateway-service) using Docker Compose
- Remove CI skip logic from integration tests
- Increase test timeouts to accommodate service startup time

## Test plan
- [ ] CI pipeline frontend integration tests job passes successfully
- [ ] Integration tests connect to actual backend services through gateway
- [ ] All authentication and chat API endpoints tested

🤖 Generated with [Qoder][https://qoder.com]